### PR TITLE
Add include guard to prevent redefining Adafruit_SharpMem

### DIFF
--- a/Adafruit_SharpMem.h
+++ b/Adafruit_SharpMem.h
@@ -15,6 +15,8 @@ Written by Limor Fried/Ladyada  for Adafruit Industries.
 BSD license, check license.txt for more information
 All text above, and the splash screen must be included in any redistribution
 *********************************************************************/
+#ifndef LIB_ADAFRUIT_SHARPMEM
+#define LIB_ADAFRUIT_SHARPMEM
 
 #if ARDUINO >= 100
  #include "Arduino.h"
@@ -68,3 +70,5 @@ class Adafruit_SharpMem : public Adafruit_GFX {
   void sendbyte(uint8_t data);
   void sendbyteLSB(uint8_t data);
 };
+
+#endif


### PR DESCRIPTION
Adds an 

```cpp
#ifndef LIB_ADAFRUIT_SHARPMEM
```

include guard to to header file so that you can include it multiple times without redefining anything.