### PR TITLE
Split the SPI initialization part of begin() into begin_spi()

### DIFF
--- a/Adafruit_SharpMem.cpp
+++ b/Adafruit_SharpMem.cpp
@@ -108,9 +108,7 @@ Adafruit_SharpMem::Adafruit_SharpMem(SPIClass *theSPI, uint8_t cs,
  * @return boolean true: success false: failure
  */
 boolean Adafruit_SharpMem::begin(void) {
-  if (!spidev->begin()) {
-    return false;
-  }
+  if (!begin_spi()) return false;
   // this display is weird in that _cs is active HIGH not LOW like every other
   // SPI device
   digitalWrite(_cs, LOW);
@@ -126,6 +124,10 @@ boolean Adafruit_SharpMem::begin(void) {
   setRotation(0);
 
   return true;
+}
+
+boolean Adafruit_SharpMem::begin_spi(void) {
+  return spidev->begin();
 }
 
 // 1<<n is a costly operation on AVR -- table usu. smaller & faster

--- a/Adafruit_SharpMem.h
+++ b/Adafruit_SharpMem.h
@@ -41,6 +41,7 @@ public:
   Adafruit_SharpMem(SPIClass *theSPI, uint8_t cs, uint16_t w = 96,
                     uint16_t h = 96, uint32_t freq = 2000000);
   boolean begin();
+  boolean begin_spi();
   void drawPixel(int16_t x, int16_t y, uint16_t color);
   uint8_t getPixel(uint16_t x, uint16_t y);
   void clearDisplay();


### PR DESCRIPTION
Split the SPI initialization part of begin() into begin_spi(). You may need to call this part of initialization manually if you use more than once device on the same SPI bus as the Sharp Memory display, as the pins will need to be reset after the other SPI bus closes (depending on the bus code that driver uses).

Does not change the functionality of begin().