### PR TITLE
Support color depth for 8 colors screen

### DIFF
--- a/Adafruit_SharpMem.h
+++ b/Adafruit_SharpMem.h
@@ -37,9 +37,11 @@ All text above, and the splash screen must be included in any redistribution
 class Adafruit_SharpMem : public Adafruit_GFX {
 public:
   Adafruit_SharpMem(uint8_t clk, uint8_t mosi, uint8_t cs, uint16_t w = 96,
-                    uint16_t h = 96, uint32_t freq = 2000000);
+                    uint16_t h = 96, uint32_t freq = 2000000,
+                    uint8_t color_depth_bits = 1);
   Adafruit_SharpMem(SPIClass *theSPI, uint8_t cs, uint16_t w = 96,
-                    uint16_t h = 96, uint32_t freq = 2000000);
+                    uint16_t h = 96, uint32_t freq = 2000000,
+                    uint8_t color_depth_bits = 1);
   boolean begin();
   void drawPixel(int16_t x, int16_t y, uint16_t color);
   uint8_t getPixel(uint16_t x, uint16_t y);
@@ -52,6 +54,7 @@ private:
   uint8_t *sharpmem_buffer = NULL;
   uint8_t _cs;
   uint8_t _sharpmem_vcom;
+  uint8_t _color_depth_bits;
 };
 
 #endif

--- a/examples/sharpmemtest/sharpmemtest.ino
+++ b/examples/sharpmemtest/sharpmemtest.ino
@@ -24,6 +24,10 @@ All text above, must be included in any redistribution
 #define SHARP_MOSI 11
 #define SHARP_SS   10
 
+// Set the size and color depth, default is 1 bit depth.
+// For example: 3 bits for LS013B7DH06 (8 colors 128x128 display)
+// Adafruit_SharpMem display(SHARP_SCK, SHARP_MOSI, SHARP_SS, 128, 128, 2000000, 3);
+
 // Set the size of the display here, e.g. 144x168!
 Adafruit_SharpMem display(SHARP_SCK, SHARP_MOSI, SHARP_SS, 144, 168);
 // The currently-available SHARP Memory Display (144x168 pixels)


### PR DESCRIPTION
Replace LS013B7DH06 from Breakout Board and tested.
It needs tripled RAM size than mono screen.

I added support for color depth because sharp sells a memory LCD with a color depth of 3. I have tested this library on that LCD with a feather m0 and it works. The part number for this LCD is LS013B7DH06 and is compatible with existing sharp memory LCD breakout boards.

