### PR TITLE
Expose sharpmem_buffer via getBuffer() for DMA transfers

### DIFF
--- a/Adafruit_SharpMem.h
+++ b/Adafruit_SharpMem.h
@@ -46,6 +46,13 @@ public:
   void clearDisplay();
   void refresh(void);
   void clearDisplayBuffer();
+  /**
+   * @brief Get a pointer to the display buffer.
+   * This allows direct access to the internal framebuffer.
+   *
+   * @return uint8_t* Pointer to the framebuffer memory.
+   */
+  uint8_t *getBuffer() { return sharpmem_buffer; }
 
 private:
   Adafruit_SPIDevice *spidev = NULL;


### PR DESCRIPTION
This PR introduces a small but important enhancement to the **Adafruit_SHARP_Memory_Display** library by exposing the internal framebuffer (`sharpmem_buffer`) via a new `getBuffer()` method.  


- Currently, `sharpmem_buffer` is declared as `private`, preventing direct access.
- This limits advanced use cases, such as DMA.
- The added `getBuffer()` function allows users to directly modify the framebuffer before calling `refresh() `.

#### **Changes Made:**

  ```cpp
  public:
    uint8_t* getBuffer() { return sharpmem_buffer; }
  ```

#### **Use Case Example:**
This change allows for **direct SPI DMA transfers**, reducing CPU overhead on fast MCUs like the Teensy 4.1:

```cpp
memcpy(display.getBuffer(), frameData, bufferSize); 
display.refresh(); 